### PR TITLE
Finished support for string config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ $RECYCLE.BIN/
 
 # IDE folders
 .idea/
+output/
+HomesThatWork.iml
 
 # Files that might appear in the root of a volume
 .DocumentRevisions-V100

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,2 +1,0 @@
-Manifest-Version: 1.0
-

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,14 @@
-# HomesThatWork Custom Messages File
+# HomesThatWork Custom Messages and Configuration File
 messages:
     prefix: "&7[&cHomesThatWork&7]"
+    # not-a-command-error is for /htw help only.
+    # Does not display a message for general invalid commands.
+    not-a-command-error:  "That is not a vaild HTW Command."
+    invalid-subcommand: "That is not a valid subcommand!"
+    admin-errors:
+        offline: "Given Player is Offline: Last known player named %arg1%: "
+        invalid-player: "That player does not exist."
+        noperm: "You do not have permission to view other players' information."
     player-errors:
         max-homes-set:  "Maxmium number of homes set."
         home-already-exists: "Home already exists."
@@ -35,6 +43,8 @@ messages:
             description: "List homes of specific player"
         homeinfo:
             description: "Lists information about a specified home"
+        htw-reload:
+            description: "Reloads the HomesThatWork configuration file"
+            success: "The HomesThatWork configuration file was reloaded!"
         htw:
-            description: "Main plugin command. See /htw help for command list."
-
+            description: "Main plugin command. See /htw help for command list"

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: HomesThatWork
 main: com.dsnyder.homesthatwork.WorkingHomes
 version: 2.3.0
 author: Dan Snyder
-description: A simple home plugin that actually works!
+description: A simple home plugin that actually works
 commands:
   homesthatwork:
     description: Main plugin command. See /htw help for command list.

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: HomesThatWork
 main: com.dsnyder.homesthatwork.WorkingHomes
-version: 2.2.0
+version: 2.3.0
 author: Dan Snyder
 description: A simple home plugin that actually works
 commands:
@@ -20,3 +20,5 @@ commands:
     description: See /htw help homeinfo
   goback:
     description: See /htw help goback
+  htw-reload:
+    description: See /htw help reload

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,8 +1,8 @@
 name: HomesThatWork
 main: com.dsnyder.homesthatwork.WorkingHomes
-version: 2.2.0
+version: 2.3.0
 author: Dan Snyder
-description: A simple home plugin that actually works
+description: A simple home plugin that actually works!
 commands:
   homesthatwork:
     description: Main plugin command. See /htw help for command list.
@@ -20,3 +20,5 @@ commands:
     description: See /htw help homeinfo
   goback:
     description: See /htw help goback
+  htw-reload:
+    description: See /htw help reload

--- a/src/com/dsnyder/homesthatwork/FileManager.java
+++ b/src/com/dsnyder/homesthatwork/FileManager.java
@@ -1,20 +1,25 @@
 package com.dsnyder.homesthatwork;
 
+import com.sun.xml.internal.ws.api.pipe.FiberContextSwitchInterceptor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.error.YAMLException;
 
 import java.io.File;
 import java.io.IOException;
 
+import static org.apache.commons.io.FileUtils.getFile;
 import static org.apache.commons.io.FileUtils.moveFile;
+import static org.apache.commons.io.FileUtils.openInputStream;
 
 /**
  *
- * AdminMip/TheMIP3 created this file to add configuration management to HTW.
+ *  AdminMip/TheMIP3 created this file to add configuration management to HTW.
+ *
  */
-public class FileManager
-{
+public class FileManager {
 
     private static File playerconf;
 
@@ -23,24 +28,21 @@ public class FileManager
 
     private static Player player;
 
-    public FileManager()
-    {
+    public FileManager() {
 
         stringconf = loadStringConf();
         prepFiles();
     }
 
     // Get the player's specific config
-    public static YamlConfiguration getHomeConf( OfflinePlayer pl )
-    {
+    public static YamlConfiguration getHomeConf(OfflinePlayer pl) {
         // Test to see if the player's config is in the root folder of the plugin
-        File testConf = new File( WorkingHomes.getPlugin().getDataFolder(), pl.getUniqueId() + ".yml" );
-        if( testConf.exists() )
-        {
+        File testConf = new File(WorkingHomes.getPlugin().getDataFolder(), pl.getUniqueId() + ".yml");
+        if (testConf.exists()) {
             try {
 
-         // if it is, move it to the new subdirectory called "home_data" and delete the old one
-                moveFile( testConf, new File( WorkingHomes.getPlugin().getDataFolder() + "/home_data/", pl.getUniqueId() + ".yml" ));
+                // if it is, move it to the new subdirectory called "home_data" and delete the old one
+                moveFile(testConf, new File(WorkingHomes.getPlugin().getDataFolder() + "/home_data/", pl.getUniqueId() + ".yml"));
                 testConf.delete();
             } catch (IOException e) {
                 e.printStackTrace();
@@ -50,7 +52,7 @@ public class FileManager
         }
 
         // Load the final version if we've moved it.  If not, just load the existing one
-        playerconf = new File( WorkingHomes.getPlugin().getDataFolder() + "/home_data/",  pl.getUniqueId() + ".yml");
+        playerconf = new File(WorkingHomes.getPlugin().getDataFolder() + "/home_data/", pl.getUniqueId() + ".yml");
 
         // Read file
         conf = YamlConfiguration.loadConfiguration(playerconf);
@@ -61,34 +63,50 @@ public class FileManager
 
 
     // Check if the home_data directory exists already.  If not, make it.
-    private void checkFileStructure()
-    {
-        File dir = new File( WorkingHomes.getPlugin().getDataFolder(), "home_data");
-        if( !(dir.exists()) ) {
+    private void checkFileStructure() {
+        File dir = new File(WorkingHomes.getPlugin().getDataFolder(), "home_data");
+        if (!(dir.exists())) {
 
             dir.mkdirs();
         }
     }
 
-    private static YamlConfiguration loadStringConf()
-    {
+    private static YamlConfiguration loadStringConf() {
 
-        File f = new File( WorkingHomes.getPlugin().getDataFolder(), "strings.yml" );
+        File f = new File(WorkingHomes.getPlugin().getDataFolder(), "config.yml");
 
-        if( !f.exists() )
-        {
+        if (!f.exists()) {
+            WorkingHomes.getPlugin().saveDefaultConfig();
+            f = new File(WorkingHomes.getPlugin().getDataFolder(), "config.yml");
+        }
+        // If the YAML is valid,
+        try {
 
-                WorkingHomes.getPlugin().saveResource( "strings.yml", true);
-            f = new File( WorkingHomes.getPlugin().getDataFolder(), "strings.yml" );
+            conf = YamlConfiguration.loadConfiguration(f);
+            System.out.println("[HomesThatWork] Attempting to load config.yml file...");
+
+        } catch (YAMLException YamlError) {
+
+            System.out.println("[HomesThatWork] There was an error parsing the config.yml file!");
+
+            try {
+                moveFile(f, new File(WorkingHomes.getPlugin().getDataFolder(), "config.yml.old"));
+            } catch (IOException e) {
+
+                System.out.println("[HomesThatWork] There was an error renaming the old file. Contact the developer!");
+            }
+            WorkingHomes.getPlugin().saveDefaultConfig();
+
+            System.out.println("[HomesThatWork] Replacing old copy with a default copy.");
+            System.out.println("[HomesThatWork] A backup was made at config.yml.old");
+
         }
 
-        conf = YamlConfiguration.loadConfiguration( f );
-        System.out.println("]HomesThatWork] Loading strings.yml file...");
         return conf;
     }
 
     // Usually works, save the home to the config.
-    public static boolean saveHomes(String msg, Player pl ) {
+    public static boolean saveHomes(String msg, Player pl) {
         try {
             conf.save(playerconf);
             return true;
@@ -101,18 +119,17 @@ public class FileManager
     }
 
     // Return the string config.  Used in MessageManager.java
-    public static YamlConfiguration getStringConf()
-    {
+    public static YamlConfiguration getStringConf() {
 
         return stringconf;
 
     }
 
-    private void prepFiles()
-    {
+    private void prepFiles() {
 
         checkFileStructure();
 
 
     }
+
 }

--- a/src/com/dsnyder/homesthatwork/HomeManager.java
+++ b/src/com/dsnyder/homesthatwork/HomeManager.java
@@ -62,20 +62,20 @@ public class HomeManager {
 		if (curHomeCount >= getMaxHomes()) {
 			// we check for greater than in case their max homes changed
 			// we do not delete the homes however -- they can choose which homes go
-			player.sendMessage( MessageManager.getPfx() + ChatColor.RED + MessageManager.getMsg( "max-homes-set" ) );
+			player.sendMessage( MessageManager.getErrorMsg( "max-homes-set" ) );
 			return;
 		}
 		
 		if (homeExists(home)) {
-			player.sendMessage( MessageManager.getPfx() + ChatColor.RED + MessageManager.getMsg( "home-exists" ) );
+			player.sendMessage( MessageManager.getErrorMsg( "home-exists" ) );
 			return;
 		}
 		// attempt to set the home and save the configuration file
 		this.config.set(home.toLowerCase(), locationToString(player.getLocation()));
 		
-		if (!FileManager.saveHomes( (MessageManager.getPfx() + ChatColor.RED + MessageManager.getMsg( "sethome-error" )), player) ) return;
+		if (!FileManager.saveHomes( ( MessageManager.getSuccessMsg( "sethome-error" )), player) ) return;
 		// send message that it was successful
-		player.sendMessage( MessageManager.getPfx() + ChatColor.GREEN + MessageManager.getMsg( "home-set" ));
+		player.sendMessage( MessageManager.getSuccessMsg( "home-set" ) );
 		curHomeCount++;
 	}
 	
@@ -84,40 +84,39 @@ public class HomeManager {
 		// let them choose which homes they lose
 		if (curHomeCount > getMaxHomes()) {
 			int hCount = curHomeCount - getMaxHomes();
-			player.sendMessage(String.format(MessageManager.getPfx() + ChatColor.RED +
-					MessageManager.getMsg("too-many-homes"), hCount, (hCount > 1) ? "s" : ""));
+			player.sendMessage(String.format(MessageManager.getErrorMsg("too-many-homes"), hCount, (hCount > 1) ? "s" : ""));
 			return;
 
 		}
 
 		// 
 		if (!homeExists(home)) {
-			player.sendMessage( MessageManager.getPfx() + ChatColor.RED + MessageManager.getMsg( "does-not-exist" ));
+			player.sendMessage( MessageManager.getErrorMsg( "does-not-exist" ));
 			return;
 		}
 		// parse values accordingly
 		Location loc = parseLocation((String) config.get(home.toLowerCase()));
 		// go to the specified location
 		if (loc == null) {
-			player.sendMessage(MessageManager.getPfx() + ChatColor.RED + MessageManager.getMsg( "corrupt-data" ));
+			player.sendMessage( MessageManager.getErrorMsg( "corrupt-data" ));
 			return;
 		}
 		
 		if (!loc.getWorld().equals(player.getWorld())) {
 			if (!PermissionManager.getManager().hasPermission(player, PERMISSION_DIMENSIONS)) {
-				player.sendMessage(MessageManager.getPfx() + ChatColor.RED + MessageManager.getMsg( "no-inter-perm" ));
+				player.sendMessage(MessageManager.getErrorMsg( "no-inter-perm" ));
 				return;
 			}
 		}
 		this.config.set(LAST_LOCATION, locationToString(player.getLocation()));
-		FileManager.saveHomes(MessageManager.getPfx() + ChatColor.RED + MessageManager.getMsg( "loc-save-error" ), player);
+		FileManager.saveHomes(MessageManager.getErrorMsg( "loc-save-error" ), player);
 		player.teleport(loc);
 	}
 	
 	public void delHome(String home) {
 		// only reason you can't delete a home is if it doesn't exist
 		if (!homeExists(home.toLowerCase())) {
-			player.sendMessage(MessageManager.getPfx() + ChatColor.RED + MessageManager.getMsg( "does-not-exist" ));
+			player.sendMessage( MessageManager.getErrorMsg( "does-not-exist" ));
 			return;
 		}
 		
@@ -125,11 +124,11 @@ public class HomeManager {
 			// remove home - should work every time
 			this.config.set(home, null);
 			this.config.save(playerconf);
-			player.sendMessage(MessageManager.getPfx() + ChatColor.RED + MessageManager.getMsg( "home-removed" ));
+			player.sendMessage(MessageManager.getSuccessMsg( "home-removed" ));
 			curHomeCount--;
 		} catch (IOException e) {
 			e.printStackTrace();
-			player.sendMessage(MessageManager.getPfx() + ChatColor.RED + MessageManager.getMsg( "home-rem-error"));
+			player.sendMessage(MessageManager.getErrorMsg( "home-rem-error"));
 		}
 	}
 	
@@ -152,7 +151,7 @@ public class HomeManager {
 	public void goBack() {
 		
 		if (!homeExists(LAST_LOCATION)) {
-			player.sendMessage(MessageManager.getPfx() + ChatColor.RED + MessageManager.getMsg( "no-prev-loc" ));
+			player.sendMessage( MessageManager.getErrorMsg( "no-prev-loc" ));
 			return;
 		}
 		
@@ -195,7 +194,7 @@ public class HomeManager {
 	
 	private String generateHomeInfo(String home) {
 		
-		if (!homeExists(home)) return ( MessageManager.getPfx() + ChatColor.RED + MessageManager.getMsg( "does-not-exist" ) );
+		if (!homeExists(home)) return ( MessageManager.getPfx() + ChatColor.RED + MessageManager.getErrorMsg( "does-not-exist" ) );
 		
 		Location loc = parseLocation((String) this.config.get(home.toLowerCase()));
 		
@@ -215,7 +214,7 @@ public class HomeManager {
 		homes.remove(LAST_LOCATION);
 		homes.remove(WorkingHomes.VERSION_KEY);
 		
-		if (homes.isEmpty()) return ( MessageManager.getPfx() + ChatColor.RED + MessageManager.getMsg( "no-homes-set") );
+		if (homes.isEmpty()) return (MessageManager.getErrorMsg( "no-homes-set") );
 		
 		String homestr = ChatColor.LIGHT_PURPLE + "Homes: \n" + ChatColor.WHITE;
 		for (String home : homes) homestr += home + ", ";

--- a/src/com/dsnyder/homesthatwork/MessageManager.java
+++ b/src/com/dsnyder/homesthatwork/MessageManager.java
@@ -17,6 +17,46 @@ public class MessageManager {
     public MessageManager()
     {
 
+        loadStrings();
+
+    }
+
+
+    private static String getConfigMsg( String path )
+    {
+
+        return conf.getString( path );
+    }
+
+    public static String getMsg( String key )
+    {
+
+        return configMsgs.get( key );
+
+    }
+    public static String getErrorMsg( String key )
+    {
+
+        return getPfx() + ChatColor.RED + configMsgs.get( key );
+
+    }
+
+    public static String getSuccessMsg( String key )
+    {
+
+        return getPfx() + ChatColor.GREEN + configMsgs.get( key );
+
+    }
+    public static String getPfx()
+    {
+
+        return PREFIX + " ";
+
+    }
+
+    public static void loadStrings()
+    {
+
         conf = FileManager.getStringConf();
 
         configMsgs = new HashMap<>();
@@ -30,8 +70,8 @@ public class MessageManager {
         configMsgs.put( "home-rem-error", getConfigMsg( "messages.player-errors.home-remove-fail" ) );
         configMsgs.put( "no-prev-loc", getConfigMsg( "messages.player-errors.no-previous-loc" ) );
         // General player messages
-        configMsgs.put( "home-set", getConfigMsg( "messages.player-msgs.home-set-successful" ) );
-        configMsgs.put( "home-removed", getConfigMsg( "messages.player-errors.home-remove-success" ) );
+        configMsgs.put( "home-set", getConfigMsg( "messages.player-msgs.home-set-success" ) );
+        configMsgs.put( "home-removed", getConfigMsg( "messages.player-msgs.home-remove-success" ) );
         // Permission errors
         configMsgs.put( "no-command-perm", getConfigMsg("messages.permission-msgs.no-command-perm" ));
         configMsgs.put( "no-inter-perm", getConfigMsg( "messages.permission-msgs.no-interdimensional-perm" ) );
@@ -39,6 +79,8 @@ public class MessageManager {
         configMsgs.put( "sethome-error", getConfigMsg( "messages.file-errors.home-set-error" ) );
         configMsgs.put( "corrupt-data", getConfigMsg( "messages.file-errors.corrupt-home-data") );
         configMsgs.put( "loc-save-error", getConfigMsg( "messages.file-errors.last-location-save-error" ) );
+        configMsgs.put( "reload-fail", getConfigMsg( "messages.file-errors.reload-fail" ) );
+
         // Command Help Descriptions
         configMsgs.put( "help-delhome", getConfigMsg( "messages.command-msgs.delhome.description") );
         configMsgs.put( "help-goback", getConfigMsg( "messages.command-msgs.goback.description" ) );
@@ -46,29 +88,82 @@ public class MessageManager {
         configMsgs.put( "help-sethome", getConfigMsg( "messages.command-msgs.sethome.description" ) );
         configMsgs.put( "help-listhomes", getConfigMsg( "messages.command-msgs.listhomes.description" ) );
         configMsgs.put( "help-homeinfo", getConfigMsg( "messages.command-msgs.homeinfo.description" ) );
-        configMsgs.put( "help-htw", getConfigMsg( "messages.command-msgs.htw" ) );
+        configMsgs.put( "help-htw", getConfigMsg( "messages.command-msgs.htw.description" ) );
+        configMsgs.put( "help-reload", getConfigMsg( "messages.command-msgs.htw-reload.description"));
+        configMsgs.put( "reloaded", getConfigMsg( "messages.command-msgs.htw-reload.success" ) );
+
+
+        // Not a (sub)command errors
+        configMsgs.put( "not-a-command", getConfigMsg( "messages.not-a-command-error" ) );
+        configMsgs.put( "not-a-subcommand", getConfigMsg( "messages.invalid-subcommand" ) );
+
+        // Admin errors
+        configMsgs.put( "no-perm-others", getConfigMsg( "messages.admin-errors.noperm" ) );
+        configMsgs.put( "offline-player", getConfigMsg( "messages.admin-errors.offline" ) );
+        configMsgs.put( "invalid-player", getConfigMsg( "messages.admin-errors.invalid-player" ) );
 
         PREFIX = ChatColor.translateAlternateColorCodes( '&', configMsgs.get( "prefix" ) );
+
     }
 
-
-    private String getConfigMsg( String path )
+    public static void reloadMsgs()
     {
 
-        return conf.getString( path );
+        configMsgs.clear();
+
+        conf = FileManager.getStringConf();
+
+        configMsgs.put( "prefix", getConfigMsg( "messages.prefix" ) );
+
+        // Player errors
+        configMsgs.put( "max-homes-set", getConfigMsg( "messages.player-errors.max-homes-set" ) );
+        configMsgs.put( "home-exists", getConfigMsg( "messages.player-errors.home-already-exists" ) );
+        configMsgs.put( "too-many-homes", getConfigMsg( "messages.player-errors.too-many-homes" ) );
+        configMsgs.put( "does-not-exist", getConfigMsg( "messages.player-errors.home-not-exist" ) );
+        configMsgs.put( "no-homes-set", getConfigMsg( "messages.player-errors.no-homes-set" ) );
+        configMsgs.put( "home-rem-error", getConfigMsg( "messages.player-errors.home-remove-fail" ) );
+        configMsgs.put( "no-prev-loc", getConfigMsg( "messages.player-errors.no-previous-loc" ) );
+
+        // General player messages
+        configMsgs.put( "home-set", getConfigMsg( "messages.player-msgs.home-set-success" ) );
+        configMsgs.put( "home-removed", getConfigMsg( "messages.player-msgs.home-remove-success" ) );
+
+        // Permission errors
+        configMsgs.put( "no-command-perm", getConfigMsg("messages.permission-msgs.no-command-perm" ));
+        configMsgs.put( "no-inter-perm", getConfigMsg( "messages.permission-msgs.no-interdimensional-perm" ) );
+
+        // File Errors
+        configMsgs.put( "sethome-error", getConfigMsg( "messages.file-errors.home-set-error" ) );
+        configMsgs.put( "corrupt-data", getConfigMsg( "messages.file-errors.corrupt-home-data") );
+        configMsgs.put( "loc-save-error", getConfigMsg( "messages.file-errors.last-location-save-error" ) );
+        configMsgs.put( "reload-fail", getConfigMsg( "messages.file-errors.reload-fail" ) );
+
+        // Command Help Descriptions
+        configMsgs.put( "help-delhome", getConfigMsg( "messages.command-msgs.delhome.description") );
+        configMsgs.put( "help-goback", getConfigMsg( "messages.command-msgs.goback.description" ) );
+        configMsgs.put( "help-home", getConfigMsg( "messages.command-msgs.home.description" ) );
+        configMsgs.put( "help-sethome", getConfigMsg( "messages.command-msgs.sethome.description" ) );
+        configMsgs.put( "help-listhomes", getConfigMsg( "messages.command-msgs.listhomes.description" ) );
+        configMsgs.put( "help-homeinfo", getConfigMsg( "messages.command-msgs.homeinfo.description" ) );
+        configMsgs.put( "help-htw", getConfigMsg( "messages.command-msgs.htw.description" ) );
+        configMsgs.put( "help-reload", getConfigMsg( "messages.command-msgs.htw-reload.description"));
+        configMsgs.put( "reload-success", getConfigMsg( "messages.command-msgs.htw-reload.success" ) );
+        configMsgs.put( "reload-failure", getConfigMsg( "messages.command-msgs.htw-reload.failure" ) );
+
+
+        // Not a (sub)command errors
+        configMsgs.put( "not-a-command", getConfigMsg( "messages.not-a-command-error" ) );
+        configMsgs.put( "not-a-subcommand", getConfigMsg( "messages.invalid-subcommand" ) );
+
+        // Admin errors
+        configMsgs.put( "no-perm-others", getConfigMsg( "messages.admin-errors.noperm" ) );
+        configMsgs.put( "offline-player", getConfigMsg( "messages.admin-errors.offline" ) );
+        configMsgs.put( "invalid-player", getConfigMsg( "messages.admin-errors.invalid-player" ) );
+
+        PREFIX = ChatColor.translateAlternateColorCodes( '&', configMsgs.get( "prefix" ) );
+
+
+
     }
 
-    public static String getMsg( String key )
-    {
-
-        return configMsgs.get( key );
-
-    }
-
-    public static String getPfx()
-    {
-
-        return PREFIX + " ";
-
-    }
 }

--- a/src/com/dsnyder/homesthatwork/MessageManager.java
+++ b/src/com/dsnyder/homesthatwork/MessageManager.java
@@ -147,8 +147,7 @@ public class MessageManager {
         configMsgs.put( "help-homeinfo", getConfigMsg( "messages.command-msgs.homeinfo.description" ) );
         configMsgs.put( "help-htw", getConfigMsg( "messages.command-msgs.htw.description" ) );
         configMsgs.put( "help-reload", getConfigMsg( "messages.command-msgs.htw-reload.description"));
-        configMsgs.put( "reload-success", getConfigMsg( "messages.command-msgs.htw-reload.success" ) );
-        configMsgs.put( "reload-failure", getConfigMsg( "messages.command-msgs.htw-reload.failure" ) );
+        configMsgs.put( "reloaded", getConfigMsg( "messages.command-msgs.htw-reload.success" ) );
 
 
         // Not a (sub)command errors

--- a/src/com/dsnyder/homesthatwork/MessageManager.java
+++ b/src/com/dsnyder/homesthatwork/MessageManager.java
@@ -17,6 +17,46 @@ public class MessageManager {
     public MessageManager()
     {
 
+        loadStrings();
+
+    }
+
+
+    private static String getConfigMsg( String path )
+    {
+
+        return conf.getString( path );
+    }
+
+    public static String getMsg( String key )
+    {
+
+        return configMsgs.get( key );
+
+    }
+    public static String getErrorMsg( String key )
+    {
+
+        return getPfx() + ChatColor.RED + configMsgs.get( key );
+
+    }
+
+    public static String getSuccessMsg( String key )
+    {
+
+        return getPfx() + ChatColor.GREEN + configMsgs.get( key );
+
+    }
+    public static String getPfx()
+    {
+
+        return PREFIX + " ";
+
+    }
+
+    public static void loadStrings()
+    {
+
         conf = FileManager.getStringConf();
 
         configMsgs = new HashMap<>();
@@ -30,8 +70,8 @@ public class MessageManager {
         configMsgs.put( "home-rem-error", getConfigMsg( "messages.player-errors.home-remove-fail" ) );
         configMsgs.put( "no-prev-loc", getConfigMsg( "messages.player-errors.no-previous-loc" ) );
         // General player messages
-        configMsgs.put( "home-set", getConfigMsg( "messages.player-msgs.home-set-successful" ) );
-        configMsgs.put( "home-removed", getConfigMsg( "messages.player-errors.home-remove-success" ) );
+        configMsgs.put( "home-set", getConfigMsg( "messages.player-msgs.home-set-success" ) );
+        configMsgs.put( "home-removed", getConfigMsg( "messages.player-msgs.home-remove-success" ) );
         // Permission errors
         configMsgs.put( "no-command-perm", getConfigMsg("messages.permission-msgs.no-command-perm" ));
         configMsgs.put( "no-inter-perm", getConfigMsg( "messages.permission-msgs.no-interdimensional-perm" ) );
@@ -39,6 +79,8 @@ public class MessageManager {
         configMsgs.put( "sethome-error", getConfigMsg( "messages.file-errors.home-set-error" ) );
         configMsgs.put( "corrupt-data", getConfigMsg( "messages.file-errors.corrupt-home-data") );
         configMsgs.put( "loc-save-error", getConfigMsg( "messages.file-errors.last-location-save-error" ) );
+        configMsgs.put( "reload-fail", getConfigMsg( "messages.file-errors.reload-fail" ) );
+
         // Command Help Descriptions
         configMsgs.put( "help-delhome", getConfigMsg( "messages.command-msgs.delhome.description") );
         configMsgs.put( "help-goback", getConfigMsg( "messages.command-msgs.goback.description" ) );
@@ -46,29 +88,78 @@ public class MessageManager {
         configMsgs.put( "help-sethome", getConfigMsg( "messages.command-msgs.sethome.description" ) );
         configMsgs.put( "help-listhomes", getConfigMsg( "messages.command-msgs.listhomes.description" ) );
         configMsgs.put( "help-homeinfo", getConfigMsg( "messages.command-msgs.homeinfo.description" ) );
-        configMsgs.put( "help-htw", getConfigMsg( "messages.command-msgs.htw" ) );
+        configMsgs.put( "help-htw", getConfigMsg( "messages.command-msgs.htw.description" ) );
+        configMsgs.put( "help-reload", getConfigMsg( "messages.command-msgs.htw-reload.description"));
+        configMsgs.put( "reloaded", getConfigMsg( "messages.command-msgs.htw-reload.success" ) );
+
+
+        // Not a (sub)command errors
+        configMsgs.put( "not-a-command", getConfigMsg( "messages.not-a-command-error" ) );
+        configMsgs.put( "not-a-subcommand", getConfigMsg( "messages.invalid-subcommand" ) );
+
+        // Admin errors
+        configMsgs.put( "no-perm-others", getConfigMsg( "messages.admin-errors.noperm" ) );
+        configMsgs.put( "offline-player", getConfigMsg( "messages.admin-errors.offline" ) );
+        configMsgs.put( "invalid-player", getConfigMsg( "messages.admin-errors.invalid-player" ) );
 
         PREFIX = ChatColor.translateAlternateColorCodes( '&', configMsgs.get( "prefix" ) );
+
     }
 
-
-    private String getConfigMsg( String path )
+    public static void reloadMsgs()
     {
 
-        return conf.getString( path );
+        configMsgs.clear();
+
+        conf = FileManager.getStringConf();
+
+        configMsgs.put( "prefix", getConfigMsg( "messages.prefix" ) );
+
+        // Player Errors
+        configMsgs.put( "max-homes-set", getConfigMsg( "messages.player-errors.max-homes-set" ) );
+        configMsgs.put( "home-exists", getConfigMsg( "messages.player-errors.home-already-exists" ) );
+        configMsgs.put( "too-many-homes", getConfigMsg( "messages.player-errors.too-many-homes" ) );
+        configMsgs.put( "does-not-exist", getConfigMsg( "messages.player-errors.home-not-exist" ) );
+        configMsgs.put( "no-homes-set", getConfigMsg( "messages.player-errors.no-homes-set" ) );
+        configMsgs.put( "home-rem-error", getConfigMsg( "messages.player-errors.home-remove-fail" ) );
+        configMsgs.put( "no-prev-loc", getConfigMsg( "messages.player-errors.no-previous-loc" ) );
+        // General player messages
+        configMsgs.put( "home-set", getConfigMsg( "messages.player-msgs.home-set-success" ) );
+        configMsgs.put( "home-removed", getConfigMsg( "messages.player-msgs.home-remove-success" ) );
+        // Permission errors
+        configMsgs.put( "no-command-perm", getConfigMsg("messages.permission-msgs.no-command-perm" ));
+        configMsgs.put( "no-inter-perm", getConfigMsg( "messages.permission-msgs.no-interdimensional-perm" ) );
+        // File Errors
+        configMsgs.put( "sethome-error", getConfigMsg( "messages.file-errors.home-set-error" ) );
+        configMsgs.put( "corrupt-data", getConfigMsg( "messages.file-errors.corrupt-home-data") );
+        configMsgs.put( "loc-save-error", getConfigMsg( "messages.file-errors.last-location-save-error" ) );
+        configMsgs.put( "reload-fail", getConfigMsg( "messages.file-errors.reload-fail" ) );
+
+        // Command Help Descriptions
+        configMsgs.put( "help-delhome", getConfigMsg( "messages.command-msgs.delhome.description") );
+        configMsgs.put( "help-goback", getConfigMsg( "messages.command-msgs.goback.description" ) );
+        configMsgs.put( "help-home", getConfigMsg( "messages.command-msgs.home.description" ) );
+        configMsgs.put( "help-sethome", getConfigMsg( "messages.command-msgs.sethome.description" ) );
+        configMsgs.put( "help-listhomes", getConfigMsg( "messages.command-msgs.listhomes.description" ) );
+        configMsgs.put( "help-homeinfo", getConfigMsg( "messages.command-msgs.homeinfo.description" ) );
+        configMsgs.put( "help-htw", getConfigMsg( "messages.command-msgs.htw.description" ) );
+        configMsgs.put( "help-reload", getConfigMsg( "messages.command-msgs.htw-reload.description"));
+        configMsgs.put( "reloaded", getConfigMsg( "messages.command-msgs.htw-reload.success" ) );
+
+
+        // Not a (sub)command errors
+        configMsgs.put( "not-a-command", getConfigMsg( "messages.not-a-command-error" ) );
+        configMsgs.put( "not-a-subcommand", getConfigMsg( "messages.invalid-subcommand" ) );
+
+        // Admin errors
+        configMsgs.put( "no-perm-others", getConfigMsg( "messages.admin-errors.noperm" ) );
+        configMsgs.put( "offline-player", getConfigMsg( "messages.admin-errors.offline" ) );
+        configMsgs.put( "invalid-player", getConfigMsg( "messages.admin-errors.invalid-player" ) );
+
+        PREFIX = ChatColor.translateAlternateColorCodes( '&', configMsgs.get( "prefix" ) );
+
+
+
     }
 
-    public static String getMsg( String key )
-    {
-
-        return configMsgs.get( key );
-
-    }
-
-    public static String getPfx()
-    {
-
-        return PREFIX + " ";
-
-    }
 }

--- a/src/com/dsnyder/homesthatwork/MessageManager.java
+++ b/src/com/dsnyder/homesthatwork/MessageManager.java
@@ -115,7 +115,7 @@ public class MessageManager {
 
         configMsgs.put( "prefix", getConfigMsg( "messages.prefix" ) );
 
-        // Player Errors
+        // Player errors
         configMsgs.put( "max-homes-set", getConfigMsg( "messages.player-errors.max-homes-set" ) );
         configMsgs.put( "home-exists", getConfigMsg( "messages.player-errors.home-already-exists" ) );
         configMsgs.put( "too-many-homes", getConfigMsg( "messages.player-errors.too-many-homes" ) );
@@ -123,12 +123,15 @@ public class MessageManager {
         configMsgs.put( "no-homes-set", getConfigMsg( "messages.player-errors.no-homes-set" ) );
         configMsgs.put( "home-rem-error", getConfigMsg( "messages.player-errors.home-remove-fail" ) );
         configMsgs.put( "no-prev-loc", getConfigMsg( "messages.player-errors.no-previous-loc" ) );
+
         // General player messages
         configMsgs.put( "home-set", getConfigMsg( "messages.player-msgs.home-set-success" ) );
         configMsgs.put( "home-removed", getConfigMsg( "messages.player-msgs.home-remove-success" ) );
+
         // Permission errors
         configMsgs.put( "no-command-perm", getConfigMsg("messages.permission-msgs.no-command-perm" ));
         configMsgs.put( "no-inter-perm", getConfigMsg( "messages.permission-msgs.no-interdimensional-perm" ) );
+
         // File Errors
         configMsgs.put( "sethome-error", getConfigMsg( "messages.file-errors.home-set-error" ) );
         configMsgs.put( "corrupt-data", getConfigMsg( "messages.file-errors.corrupt-home-data") );
@@ -144,7 +147,8 @@ public class MessageManager {
         configMsgs.put( "help-homeinfo", getConfigMsg( "messages.command-msgs.homeinfo.description" ) );
         configMsgs.put( "help-htw", getConfigMsg( "messages.command-msgs.htw.description" ) );
         configMsgs.put( "help-reload", getConfigMsg( "messages.command-msgs.htw-reload.description"));
-        configMsgs.put( "reloaded", getConfigMsg( "messages.command-msgs.htw-reload.success" ) );
+        configMsgs.put( "reload-success", getConfigMsg( "messages.command-msgs.htw-reload.success" ) );
+        configMsgs.put( "reload-failure", getConfigMsg( "messages.command-msgs.htw-reload.failure" ) );
 
 
         // Not a (sub)command errors

--- a/src/com/dsnyder/homesthatwork/WorkingHomes.java
+++ b/src/com/dsnyder/homesthatwork/WorkingHomes.java
@@ -26,7 +26,7 @@ public class WorkingHomes extends JavaPlugin {
 
 	public String getStringConfig()
 	{
-		return WorkingHomes.getPlugin().getDataFolder().getPath() + File.separator + "strings.yml";
+		return WorkingHomes.getPlugin().getDataFolder().getPath() + File.separator + "config.yml";
 	}
 
 	@Override
@@ -36,4 +36,6 @@ public class WorkingHomes extends JavaPlugin {
 	public static JavaPlugin getPlugin() {
 		return main;
 	}
+
+
 }

--- a/src/com/dsnyder/homesthatwork/commands/CommandManager.java
+++ b/src/com/dsnyder/homesthatwork/commands/CommandManager.java
@@ -22,7 +22,10 @@ public class CommandManager {
 		registerCommand(new ListHomesCommand());
 		registerCommand(new HomeInfoCommand());
 		registerCommand(new GoBackCommand());
+		registerCommand(new ReloadCommand());
 		registerCommand(new HTWCommand());
+
+
 	}
 	
 	public void registerCommand(GenericCommand cmd) {

--- a/src/com/dsnyder/homesthatwork/commands/GenericCommand.java
+++ b/src/com/dsnyder/homesthatwork/commands/GenericCommand.java
@@ -47,8 +47,8 @@ public abstract class GenericCommand implements TabExecutor {
 	}
 	
 	public String getHelp() {
-		return ChatColor.GOLD + "/" + getName() + ": " + ChatColor.WHITE + 
-				getDescription() + "\n" + ChatColor.GOLD + "Usage: " + ChatColor.WHITE + getUsage();
+		return ChatColor.YELLOW + "/" + getName() + ": " + ChatColor.GRAY +
+				getDescription() + "\n" + ChatColor.YELLOW + "Usage: " + ChatColor.GRAY + getUsage();
 	}
 	
 	public void initializeHomeManager(CommandSender sender) {
@@ -59,7 +59,7 @@ public abstract class GenericCommand implements TabExecutor {
 		
 		homeManager = new HomeManager((OfflinePlayer) sender);
 	}
-	
+
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 		
@@ -70,7 +70,7 @@ public abstract class GenericCommand implements TabExecutor {
 		if (permission == null || PermissionManager.getManager().hasPermission(sender, getPermission())) {
 			return execute(sender, args);
 		} else {
-			sender.sendMessage(ChatColor.RED + MessageManager.getMsg("no-command-perm"));
+			sender.sendMessage(MessageManager.getErrorMsg("no-command-perm"));
 			return true;
 		}
 	}

--- a/src/com/dsnyder/homesthatwork/commands/HTWCommand.java
+++ b/src/com/dsnyder/homesthatwork/commands/HTWCommand.java
@@ -64,7 +64,7 @@ public class HTWCommand extends GenericCommand {
 			sender.sendMessage(getHelp());
 		} else if (args[0].equalsIgnoreCase("help")) {
 			
-			String help = "";
+			String help = "===== HomesThatWork Help =====\n\n";
 			
 			if (args.length == 1) {
 				for (GenericCommand cmd : CommandManager.getManager().getCommands()) {
@@ -78,7 +78,7 @@ public class HTWCommand extends GenericCommand {
 					}
 				}
 				
-				sender.sendMessage(ChatColor.RED + "Not a HTW Command.");
+				sender.sendMessage( MessageManager.getErrorMsg( "not-a-command" ));
 			} else {
 				return false;
 			}
@@ -87,7 +87,7 @@ public class HTWCommand extends GenericCommand {
 		} else if (args[0].equalsIgnoreCase("version")) {
 			sender.sendMessage("HomesThatWork Version " + WorkingHomes.CURRENT_VERSION);
 		} else {
-			sender.sendMessage(ChatColor.RED + "Invalid subcommand.");
+			sender.sendMessage( MessageManager.getErrorMsg( "not-a-subcommand" ) );
 		}
 		
 		return true;

--- a/src/com/dsnyder/homesthatwork/commands/HomeInfoCommand.java
+++ b/src/com/dsnyder/homesthatwork/commands/HomeInfoCommand.java
@@ -37,8 +37,8 @@ public class HomeInfoCommand extends GenericCommand {
 			for (OfflinePlayer p : Bukkit.getOfflinePlayers()) {
 				if (p.getName().equalsIgnoreCase(arg3[0])) {
 					if (!p.isOnline())
-						arg0.sendMessage(ChatColor.YELLOW + "Offline: Last known player named " + arg3[0]);
-					
+
+						arg0.sendMessage( MessageManager.getPfx() + MessageManager.getMsg( "offline-player" ).replace( "%arg1%", arg3[0]) );
 					HomeManager other = new HomeManager(p);
 					
 					homes = other.getHomeList();
@@ -89,16 +89,18 @@ public class HomeInfoCommand extends GenericCommand {
     			for (OfflinePlayer p : Bukkit.getOfflinePlayers()) {
     				if (p.getName().equalsIgnoreCase(args[0])) {
     					if (!p.isOnline())
-    						sender.sendMessage(ChatColor.YELLOW + "Offline: Last known player named " + args[0]);
+							// Prefix + neutral message, replacing %arg1% with the playername.
+    						sender.sendMessage(MessageManager.getPfx() + MessageManager.getMsg( "offline-player" ).replace( "%arg1%", args[0]) );
     					homeManager.homeInfo(p, args[1]);
     					return true;
     				}
     			}
     			
-    			sender.sendMessage(ChatColor.RED + "Player does not exist");
+    			sender.sendMessage(MessageManager.getErrorMsg( "invalid-player" ));
+
     		}
 		} else if (args.length == 2) {
-			sender.sendMessage(ChatColor.RED + "You do not have permission to view other players' information.");
+			sender.sendMessage( MessageManager.getErrorMsg( "no-perm-others" ));
 		} else {
 			// invalid number of args
 			return false;

--- a/src/com/dsnyder/homesthatwork/commands/ListHomesCommand.java
+++ b/src/com/dsnyder/homesthatwork/commands/ListHomesCommand.java
@@ -2,6 +2,7 @@ package com.dsnyder.homesthatwork.commands;
 
 import java.util.List;
 
+import com.avaje.ebeaninternal.server.cluster.mcast.Message;
 import com.dsnyder.homesthatwork.MessageManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -35,16 +36,16 @@ public class ListHomesCommand extends GenericCommand {
     			// sort through offline players
     			for (OfflinePlayer p : Bukkit.getOfflinePlayers()) {
     				if (p.getName().equalsIgnoreCase(args[0])) {
-    					sender.sendMessage(ChatColor.YELLOW + "Offline: Last known player named " + args[0]);
+    					sender.sendMessage( MessageManager.getPfx() + MessageManager.getMsg( "offline-player" ).replace( "%arg1% ", args[0]));
     					homeManager.listHomes(p);
     					return true;
     				}
     			}
     			
-    			sender.sendMessage(ChatColor.RED + "Player does not exist");
+    			sender.sendMessage(MessageManager.getErrorMsg( "invalid-player" ) );
     		}
 		} else if (args.length == 1) {
-			sender.sendMessage(ChatColor.RED + "You do not have permission to view other players' information.");
+			sender.sendMessage(MessageManager.getErrorMsg( "no-perm-others"));
 		} else if (args.length == 0) {
 			homeManager.listHomes();
 		} else {

--- a/src/com/dsnyder/homesthatwork/commands/ReloadCommand.java
+++ b/src/com/dsnyder/homesthatwork/commands/ReloadCommand.java
@@ -1,0 +1,47 @@
+package com.dsnyder.homesthatwork.commands;
+
+import com.avaje.ebeaninternal.server.cluster.mcast.Message;
+import com.dsnyder.homesthatwork.MessageManager;
+import com.dsnyder.homesthatwork.WorkingHomes;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.yaml.snakeyaml.error.YAMLException;
+
+import java.util.List;
+
+/**
+ * Created by TheMIP3 on 11/3/16.
+ */
+public class ReloadCommand extends GenericCommand {
+
+    public ReloadCommand()
+    {
+
+        super( "htw-reload", MessageManager.getMsg( "help-reload" ), "/htw-reload", "homesthatwork.command.reload");
+
+    }
+
+    @Override
+    protected boolean execute(CommandSender sender, String[] args) {
+
+if( !(sender instanceof Player) ) {
+
+    WorkingHomes.getPlugin().reloadConfig();
+    MessageManager.reloadMsgs();
+    sender.sendMessage( "[HomesThatWork] All HomesThatWork messages reloaded!" );
+
+} else {
+
+        WorkingHomes.getPlugin().reloadConfig();
+        MessageManager.reloadMsgs();
+        sender.sendMessage(MessageManager.getSuccessMsg( "reloaded" ));
+            }
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender commandSender, Command command, String s, String[] strings) {
+        return null;
+    }
+}


### PR DESCRIPTION
**String Customization Complete**

I have renamed the strings.yml to config.yml, to enable the ability to reload more easily.
  - I added a htw-reload command.  It should enable the ability to reload the config after re-uploading or editing the file.  
    - Do note that the only current configurable options are strings used in output to the user.  Any suggestions are welcome!

EDIT:  There is a bug in the htw-reload command that is fixed with the newest pull request.

Best wishes,
 ~ Mip  
